### PR TITLE
Add permissions for admin and unauthenticated users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,7 +165,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # PyPI configuration file
 .pypirc

--- a/core/settings.py
+++ b/core/settings.py
@@ -10,6 +10,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 import os
+from datetime import timedelta
+
 from dotenv import load_dotenv
 from pathlib import Path
 
@@ -37,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "rest_framework_simplejwt",
     # 3rd party apps
     # local apps
     "library",
@@ -121,3 +124,18 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": (
+        "rest_framework.permissions.AllowAny",
+    )
+}
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
+    "ROTATE_REFRESH_TOKENS": True
+}

--- a/library/permissions.py
+++ b/library/permissions.py
@@ -1,0 +1,26 @@
+from rest_framework.permissions import BasePermission
+
+
+class CustomPermission(BasePermission):
+    """
+    Only admin users can create/update/delete books
+    All users (even unauthenticated ones) should be able to list books
+    """
+    def has_permission(self, request, view):
+        if request.method in ("GET", "HEAD", "OPTIONS"):
+            return True
+        elif request.method in ("POST", "PUT", "PATCH", "DELETE"):
+            return request.user.is_authenticated and request.user.is_staff
+        return False
+
+
+# class IsAdminOrIfAuthenticatedReadOnly(BasePermission):
+#     def has_permission(self, request, view):
+#         return bool(
+#             (
+#                 request.method in SAFE_METHODS
+#                 and request.user
+#                 and request.user.is_authenticated
+#             )
+#             or (request.user and request.user.is_staff)
+#         )

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,14 @@
+from django.urls import path
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+    TokenVerifyView,
+)
+
+app_name = "user"
+
+urlpatterns = [
+    path("token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("token/verify/", TokenVerifyView.as_view(), name="token_verify"),
+]


### PR DESCRIPTION
"Add permissions to the Books Service
a. Only admin users can create/update/delete books

b. All users (even unauthenticated ones) should be able to list books

c. Use JWT token authentication from the users service"